### PR TITLE
Add support for variants and additional classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.0.3
+## 2019-05-03
+
+1. [](#improved)
+    * Fixed issues with other colons inline with icons, eg. in times.
+    * Documented conflict with Markdown Extra definition lists.
+
+
 # v1.0.2
 ## 2019-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,13 @@
-# v1.0.3
-## 2019-05-03
+# v1.1.0
+## 2019-06-15
 
-1. [](#improved)
-    * Fixed issues with other colons inline with icons, eg. in times.
-    * Documented conflict with Markdown Extra definition lists.
-
-
-# v1.0.2
-## 2019-04-20
-
-1. [](#improved)
+1. [](#new)
     * Added support for variants (eg. `fas`, `fal`).
     * Added support for additional arbitrary classes (eg. `fa-spin`, `icon`).
+
+2. [](#improved)
+    * Fixed issues with other colons inline with icons, eg. in times.
+    * Documented conflict with Markdown Extra definition lists.
 
 
 # v1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.0.2
+## 2019-04-20
+
+1. [](#improved)
+    * Added support for variants (eg. `fas`, `fal`).
+    * Added support for additional arbitrary classes (eg. `fa-spin`, `icon`).
+
+
 # v1.0.1
 ## 2016-04-27
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Joshua Lotz
+Copyright (c) 2016 Joshua Lotz, 2019 Nathan Parsons
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The plugin works by looking for colon-wrapped icon names starting with the `:fa-
 
 This plugin doesn't contain the actual Font Awesome fonts, so make sure you are using a plugin or theme (such as Learn2 or Antimatter) that include the Font Awesome assets.
 
-Also, Markdown Extra must be disabled.
+Also, this plugin conflicts with definition lists in Markdown Extra; if enabled, icons appearing at the start of a line will be treated as part of definitions and will be broken. This currently appears to be the only conflict.
 
 ## Manual installation
 
@@ -45,7 +45,7 @@ Grab a cup of <i class="fa fa-coffee"></i> and write some <i class="fa fa-code">
 
 ## Known limitations
 
-- Does not work with Markdown Extra enabled (conflicts with definition lists which start with a colon)
+- Conflicts with Markdown Extra definition lists. If Markdown Extra is enabled, icons cannnot be placed at the start of a line and must have at least one non-whitespace character preceeding them.
 - Icon names are not validated, so html tags are created even for non-existent icons like `:fa-not-a-real-icon:``
 
 ## Alternatives

--- a/README.md
+++ b/README.md
@@ -4,21 +4,38 @@ The **Font Awesome plugin** for [Grav](http://github.com/getgrav/grav) allows yo
 
 ![Font Awesome flag icon](assets/fa-flag-to-icon.png)
 
+**Note:** [N-Parsons/markdown-fontawesome](https://github.com/n-parsons/grav-plugin-markdown-fontawesome) is the new master repository for this plugin (see [getgrav/grav#2544](https://github.com/getgrav/grav/issues/2544)).
+
 ## Prerequisites
 
-The plugin works by looking for colon-wrapped icon names starting with the `:fa-` prefix or `:fa[srlb]? fa-` and converting them to `<i>` tags. Additional classes (including `fa-spin`, etc.) may be specified by including them at the end.
+The plugin works by looking for colon-wrapped icon names starting with `fas fa-`, `far fa-`, `fal fa-`, or `fab fa-` (or `fa fa-` for Font Awesome 4), and converting them to `<i>` tags. Additional classes (including `fa-spin`, etc.) may be specified by including them at the end. Primarily for legacy reasons, the plugin also supports a shortened prefix format, namely `fa-`, which works for both Font Awesome 4 and 5, and inserts `<i class="fa fas fa-*"></i>`.
 
 This plugin doesn't contain the actual Font Awesome fonts, so make sure you are using a plugin or theme (such as Learn2 or Antimatter) that include the Font Awesome assets.
 
-Also, this plugin conflicts with definition lists in Markdown Extra; if enabled, icons appearing at the start of a line will be treated as part of definitions and will be broken. This currently appears to be the only conflict.
+## Conflicts
 
-## Manual installation
+This plugin conflicts with definition lists in Markdown Extra; if enabled, icons appearing at the start of a line (with no non-whitespace character preceeding them) will be treated as part of a definition list and will be broken. This currently appears to be the only conflict.
 
-Download zip version of this repository, unzip to `/your/site/grav/user/plugins` and rename directory to `markdown-fontawesome`.
+If this conflict with Markdown Extra is an issue for you, you can either switch to [Shortcode Core](https://github.com/grav/grav-plugin-shortcode-core), or disable Markdown Extra per-page by adding the following to the page frontmatter:
+
+```
+markdown:
+  extra: false
+```
+
+## Installation
+
+### GPM (preferred method)
+
+You can install the plugin by running `bin/gpm install markdown-fontawesome` or searching for `markdown-fontawesome` in the Admin Panel.
+
+### Manual installation
+
+Alternatively, you can download the zip version of this repository, unzip to `/your/site/grav/user/plugins` and rename the directory to `markdown-fontawesome`.
 
 ## Configuration
 
-The markdown-fontawesome.yaml file contains only one configuration which turns the plugin on/off.
+The `markdown-fontawesome.yaml` file contains only one configuration option, which turns the plugin on/off.
 
 ```
 enabled: true
@@ -27,19 +44,20 @@ enabled: true
 ## Examples
 
 ```
-Grab a cup of :fa-coffee: and write some :fa-code:
+Grab a cup of :fas fa-coffee: and write some :fal fa-code:
 ```
 
 Will produce the following HTML:
 
 ```
-Grab a cup of <i class="fa fa-coffee"></i> and write some <i class="fa fa-code"></i>
+Grab a cup of <i class="fas fa-coffee"></i> and write some <i class="fal fa-code"></i>
 ```
 
 ### Extra classes
 
+Additional classes can be specified by appending them after the icon name.
+
 - `:fa-code fa-spin:` -> `<i class="fa fa-code fa-spin"></i>`
-- `:fa-code fas fa-spin:` -> `<i class="fa fa-code fas fa-spin"></i>`
 - `:fas fa-code fa-spin icon:` -> `<i class="fas fa-code fa-spin icon"></i>`
 - `:far fa-code literally any other classes:` -> `<i class="far fa-code literally any other classes"></i>`
 
@@ -50,12 +68,12 @@ Grab a cup of <i class="fa fa-coffee"></i> and write some <i class="fa fa-code">
 
 ## Alternatives
 
-If you prefer shortcode syntax `[fa=cog extra=fas /]`, consider using the [Grav Shortcode Plugin](https://github.com/getgrav/grav-plugin-shortcode-core#fontawesome) which also supports Font Awesome.
+If you prefer shortcode syntax, consider using the [Grav Shortcode Plugin](https://github.com/getgrav/grav-plugin-shortcode-core#fontawesome) which also supports Font Awesome via `[fa=cog extra=fas /]`.
 
 ## License
 
-MIT license. See [LICENSE](LICENSE.txt)
+MIT license. See [LICENSE](LICENSE)
 
-## Cred
+## Credits
 
-This plugin was inspired by the python markdown extension [fontawesome-markdown](https://github.com/bmcorser/fontawesome-markdown) and the first version was based on code from the [Grav Markdown Color Plugin](https://github.com/getgrav/grav-plugin-markdown-color).
+This plugin was originally developed by (yoshikin)[https://github.com/yoshikin]. It was inspired by the python markdown extension [fontawesome-markdown](https://github.com/bmcorser/fontawesome-markdown) and the first version was based on code from the [Grav Markdown Color Plugin](https://github.com/getgrav/grav-plugin-markdown-color).

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@ The **Font Awesome plugin** for [Grav](http://github.com/getgrav/grav) allows yo
 
 ![Font Awesome flag icon](assets/fa-flag-to-icon.png)
 
-# Prerequisites
+## Prerequisites
 
-The plugin works by looking for colon-wrapped icon names starting with the `:fa-` prefix and converting them to `<i>` tags.
+The plugin works by looking for colon-wrapped icon names starting with the `:fa-` prefix or `:fa[srlb]? fa-` and converting them to `<i>` tags. Additional classes (including `fa-spin`, etc.) may be specified by including them at the end.
 
 This plugin doesn't contain the actual Font Awesome fonts, so make sure you are using a plugin or theme (such as Learn2 or Antimatter) that include the Font Awesome assets.
 
 Also, Markdown Extra must be disabled.
 
-# Manual installation
+## Manual installation
 
 Download zip version of this repository, unzip to `/your/site/grav/user/plugins` and rename directory to `markdown-fontawesome`.
 
-# Configuration
+## Configuration
 
 The markdown-fontawesome.yaml file contains only one configuration which turns the plugin on/off.
 
@@ -24,7 +24,7 @@ The markdown-fontawesome.yaml file contains only one configuration which turns t
 enabled: true
 ```
 
-# Examples
+## Examples
 
 ```
 Grab a cup of :fa-coffee: and write some :fa-code:
@@ -36,20 +36,26 @@ Will produce the following HTML:
 Grab a cup of <i class="fa fa-coffee"></i> and write some <i class="fa fa-code"></i>
 ```
 
-# Known limitations
+### Extra classes
+
+- `:fa-code fa-spin:` -> `<i class="fa fa-code fa-spin"></i>`
+- `:fa-code fas fa-spin:` -> `<i class="fa fa-code fas fa-spin"></i>`
+- `:fas fa-code fa-spin icon:` -> `<i class="fas fa-code fa-spin icon"></i>`
+- `:far fa-code literally any other classes:` -> `<i class="far fa-code literally any other classes"></i>`
+
+## Known limitations
 
 - Does not work with Markdown Extra enabled (conflicts with definition lists which start with a colon)
 - Icon names are not validated, so html tags are created even for non-existent icons like `:fa-not-a-real-icon:``
-- Additional fa classes such as `fa-spin` and `fa-2x` not yet supported.
 
-# Alternatives
+## Alternatives
 
-If you prefer shortcode syntax `[fa=cog /]`, consider using the [Grav Shortcode Plugin](https://github.com/getgrav/grav-plugin-shortcode-core#fontawesome) which also supports Font Awesome.
+If you prefer shortcode syntax `[fa=cog extra=fas /]`, consider using the [Grav Shortcode Plugin](https://github.com/getgrav/grav-plugin-shortcode-core#fontawesome) which also supports Font Awesome.
 
-# License
+## License
 
 MIT license. See [LICENSE](LICENSE.txt)
 
-# Cred
+## Cred
 
 This plugin was inspired by the python markdown extension [fontawesome-markdown](https://github.com/bmcorser/fontawesome-markdown) and the first version was based on code from the [Grav Markdown Color Plugin](https://github.com/getgrav/grav-plugin-markdown-color).

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,11 +1,14 @@
 name: Markdown Font Awesome
-version: 1.0.1
+version: 1.1.0
 description: "Adds support for Font Awesome icons in Markdown using :emoji: syntax"
 icon: flag
 author:
-  name: Joshua Lotz
-  email: joshualotz@gmail.com
-  url: https://github.com/yoshikin
+  name: Nathan Parsons
+  email: github@tantalum.blue
+  url: https://github.com/n-parsons
+homepage: https://github.com/n-parsons/grav-plugin-markdown-fontawesome
+keywords: font awesome, emoji, icons
+bugs: https://github.com/n-parsons/grav-plugin-markdown-fontawesome/issues
 license: MIT
 
 form:

--- a/markdown-fontawesome.php
+++ b/markdown-fontawesome.php
@@ -21,12 +21,13 @@ class MarkdownFontAwesomePlugin extends Plugin
         $markdown = $event['markdown'];
 
         // Initialize Text example
-        $markdown->addInlineType(':', 'FontAwesome');
+        $markdown->addInlineType(':', 'FontAwesome');     // Backwards compatibility
+        $markdown->addInlineType(':', 'FontAwesomePro');  // Widened support
 
         // Add function to handle this
         $markdown->inlineFontAwesome = function($excerpt) {
             // Search $excerpt['text'] for regex and store whole matching string in $matches[0], store icon name in $matches[1]
-            if (preg_match('/:fa-([-\w]+):/', $excerpt['text'], $matches))
+            if (preg_match('/:fa-([a-zA-Z0-9- ]+):/', $excerpt['text'], $matches))
             {
                 return array(
                     'extent' => strlen($matches[0]),
@@ -35,6 +36,24 @@ class MarkdownFontAwesomePlugin extends Plugin
                         'text' => '',
                         'attributes' => array(
                             'class' => 'fa fa-'.$matches[1],
+                        ),
+                    ),
+                );
+            }
+        };
+
+        // Add function to handle this
+        $markdown->inlineFontAwesomePro = function($excerpt) {
+            // Search $excerpt['text'] for regex and store whole matching string in $matches[0], store icon name in $matches[1]
+            if (preg_match('/:fa([srlb]?) fa-([a-zA-Z0-9- ]+):/', $excerpt['text'], $matches))
+            {
+                return array(
+                    'extent' => strlen($matches[0]),
+                    'element' => array(
+                        'name' => 'i',
+                        'text' => '',
+                        'attributes' => array(
+                            'class' => 'fa'.$matches[1].' fa-'.$matches[2],
                         ),
                     ),
                 );

--- a/markdown-fontawesome.php
+++ b/markdown-fontawesome.php
@@ -34,7 +34,7 @@ class MarkdownFontAwesomePlugin extends Plugin
                         'name' => 'i',
                         'text' => '',
                         'attributes' => array(
-                            'class' => 'fa fa-'.$matches[1],
+                            'class' => 'fa fas fa-'.$matches[1],
                         ),
                     ),
                 );

--- a/markdown-fontawesome.php
+++ b/markdown-fontawesome.php
@@ -21,13 +21,12 @@ class MarkdownFontAwesomePlugin extends Plugin
         $markdown = $event['markdown'];
 
         // Initialize Text example
-        $markdown->addInlineType(':', 'FontAwesome');     // Backwards compatibility
-        $markdown->addInlineType(':', 'FontAwesomePro');  // Widened support
+        $markdown->addInlineType(':', 'FontAwesome');
 
         // Add function to handle this
         $markdown->inlineFontAwesome = function($excerpt) {
             // Search $excerpt['text'] for regex and store whole matching string in $matches[0], store icon name in $matches[1]
-            if (preg_match('/:fa-([a-zA-Z0-9- ]+):/', $excerpt['text'], $matches))
+            if (preg_match('/^:fa-([a-zA-Z0-9- ]+):/', $excerpt['text'], $matches))
             {
                 return array(
                     'extent' => strlen($matches[0]),
@@ -40,12 +39,7 @@ class MarkdownFontAwesomePlugin extends Plugin
                     ),
                 );
             }
-        };
-
-        // Add function to handle this
-        $markdown->inlineFontAwesomePro = function($excerpt) {
-            // Search $excerpt['text'] for regex and store whole matching string in $matches[0], store icon name in $matches[1]
-            if (preg_match('/:fa([srlb]?) fa-([a-zA-Z0-9- ]+):/', $excerpt['text'], $matches))
+            elseif (preg_match('/^:fa([srlb]?) fa-([a-zA-Z0-9- ]+):/', $excerpt['text'], $matches))
             {
                 return array(
                     'extent' => strlen($matches[0]),


### PR DESCRIPTION
This PR adds support for variants (ie. `fas`, `far`, `fal`, and `fab`), as well as additional classes such as `fa-spin`, `fa-2x`, etc. Arbitrary additional classes are allowed and need not start with `fa-`.